### PR TITLE
Allow customising where the ray.php config file can go with an env va…

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -109,7 +109,8 @@ class Ray
 
     public static function create(?Client $client = null, ?string $uuid = null): self
     {
-        $settings = SettingsFactory::createFromConfigFile();
+        $configDir = (isset($_SERVER['RAY_CONFIG_DIR'])) ? $_SERVER['RAY_CONFIG_DIR'] : null;
+        $settings = SettingsFactory::createFromConfigFile($configDir);
 
         return new static($settings, $client, $uuid);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -46,7 +46,8 @@ if (! function_exists('ray')) {
             $rayClass = SymfonyRay::class;
         }
 
-        $settings = SettingsFactory::createFromConfigFile();
+        $configDir = (isset($_SERVER['RAY_CONFIG_DIR'])) ? $_SERVER['RAY_CONFIG_DIR'] : null;
+        $settings = SettingsFactory::createFromConfigFile($configDir);
 
         return (new $rayClass($settings))->send(...$args);
     }


### PR DESCRIPTION
…riable.

Setting the env variable RAY_CONFIG_DIR will look for ray.php in that directory instead of in the root project directory. This allows us to separate our config out of the main codebase.